### PR TITLE
[GUI] NumberFormatException im TimePicker vermeiden

### DIFF
--- a/src/main/java/rmblworx/tools/timey/gui/component/TimePicker.java
+++ b/src/main/java/rmblworx/tools/timey/gui/component/TimePicker.java
@@ -216,7 +216,11 @@ public class TimePicker extends AnchorPane {
 		textField.focusedProperty().addListener(new ChangeListener<Boolean>() {
 			public void changed(final ObservableValue<? extends Boolean> property, final Boolean oldValue, final Boolean newValue) {
 				if (Boolean.FALSE.equals(newValue)) {
-					textProperty.setValue(getTwoDigitValue(Long.parseLong(textProperty.get())));
+					try {
+						textProperty.setValue(getTwoDigitValue(Long.parseLong(textProperty.get())));
+					} catch (final NumberFormatException e) {
+						textProperty.setValue(getTwoDigitValue(MIN_VALUE));
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Trat bei testweiser Umstellung auf Java 8 auf. Kann nicht schaden, den Code unabhängig davon robuster zu gestalten.
