### PR TITLE
Konfigurationsdatei umbenannt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /bin
 /create-target-symlink.bat
 /target
-/Timey.config.xml
+/timey.config.xml
 alarmdb.h2.db
 alarmdb.trace.db
 alarmdb.lock.db

--- a/src/main/java/rmblworx/tools/timey/gui/Main.java
+++ b/src/main/java/rmblworx/tools/timey/gui/Main.java
@@ -23,7 +23,7 @@ public class Main extends Application {
 	/**
 	 * Dateiname der Konfigurationsdatei (kann auch Pfad enthalten).
 	 */
-	private static final String CONFIG_FILENAME = "Timey.config.xml";
+	private static final String CONFIG_FILENAME = "timey.config.xml";
 
 	/**
 	 * Startet die Anwendung.


### PR DESCRIPTION
Kleinschreibung in Anlehnung an `timey.jar`
