### PR TITLE
[GUI] Konfigurationsdatei nur speichern, wenn Werte geändert wurden

### DIFF
--- a/src/main/java/rmblworx/tools/timey/gui/Main.java
+++ b/src/main/java/rmblworx/tools/timey/gui/Main.java
@@ -56,7 +56,16 @@ public class Main extends Application {
 	 * Beendet die Anwendung.
 	 */
 	public final void stop() {
-		new FileConfigStorage().saveToFile(ConfigManager.getCurrentConfig(), CONFIG_FILENAME);
+		/*
+		 * Konfigurationsdatei nur speichern, wenn Werte geändert wurden.
+		 * Nicht anhand der Abweichung zur Standardkonfiguration entscheiden, ob gespeichert werden soll, weil durch Änderungen auch
+		 * zufälligerweise wieder die Werte der Standardkonfiguration gesetzt werden könnten und diese dann nicht für den nächsten Start
+		 * übernommen werden würden.
+		 */
+		if (ConfigManager.getCurrentConfig().isChanged()) {
+			new FileConfigStorage().saveToFile(ConfigManager.getCurrentConfig(), CONFIG_FILENAME);
+		}
+
 		System.exit(0);
 	}
 

--- a/src/main/java/rmblworx/tools/timey/gui/config/Config.java
+++ b/src/main/java/rmblworx/tools/timey/gui/config/Config.java
@@ -17,6 +17,11 @@ public class Config {
 	public static final Locale[] AVAILABLE_LOCALES = {Locale.GERMAN, Locale.ENGLISH};
 
 	/**
+	 * Ob die Konfiguration geändert wurde.
+	 */
+	private boolean changed = false;
+
+	/**
 	 * Sprache.
 	 */
 	private Locale locale = Locale.GERMAN;
@@ -36,7 +41,19 @@ public class Config {
 	 */
 	private int activeTab = 0;
 
+	public void setChanged(final boolean changed) {
+		this.changed = changed;
+	}
+
+	public boolean isChanged() {
+		return changed;
+	}
+
 	public void setLocale(final Locale locale) {
+		if (this.locale != locale) {
+			changed = true;
+		}
+
 		this.locale = locale;
 	}
 
@@ -45,6 +62,10 @@ public class Config {
 	}
 
 	public void setMinimizeToTray(final boolean minimizeToTray) {
+		if (this.minimizeToTray != minimizeToTray) {
+			changed = true;
+		}
+
 		this.minimizeToTray = minimizeToTray;
 	}
 
@@ -53,6 +74,10 @@ public class Config {
 	}
 
 	public void setStopwatchShowMilliseconds(final boolean stopwatchShowMilliseconds) {
+		if (this.stopwatchShowMilliseconds != stopwatchShowMilliseconds) {
+			changed = true;
+		}
+
 		this.stopwatchShowMilliseconds = stopwatchShowMilliseconds;
 	}
 
@@ -60,12 +85,16 @@ public class Config {
 		return stopwatchShowMilliseconds;
 	}
 
-	public int getActiveTab() {
-		return activeTab;
+	public void setActiveTab(final int activeTab) {
+		if (this.activeTab != activeTab) {
+			changed = true;
+		}
+
+		this.activeTab = activeTab;
 	}
 
-	public void setActiveTab(final int activeTab) {
-		this.activeTab = activeTab;
+	public int getActiveTab() {
+		return activeTab;
 	}
 
 }

--- a/src/main/java/rmblworx/tools/timey/gui/config/ConfigStorage.java
+++ b/src/main/java/rmblworx/tools/timey/gui/config/ConfigStorage.java
@@ -30,6 +30,7 @@ public class ConfigStorage {
 
 		try {
 			props.storeToXML(outputStream, null);
+			config.setChanged(false);
 		} catch (final IOException e) {
 			System.err.println(e.getLocalizedMessage());
 		}
@@ -52,7 +53,9 @@ public class ConfigStorage {
 		try {
 			final Properties props = new Properties();
 			props.loadFromXML(inputStream);
-			return getPropertiesAsConfig(props);
+			final Config config = getPropertiesAsConfig(props);
+			config.setChanged(false);
+			return config;
 		} catch (final IOException e) {
 			if (!suppressErrors) {
 				System.err.println("Error while trying to load the config file: " + e.getLocalizedMessage());

--- a/src/test/java/rmblworx/tools/timey/gui/config/ConfigStorageTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/config/ConfigStorageTest.java
@@ -1,6 +1,7 @@
 package rmblworx.tools.timey.gui.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -113,6 +114,43 @@ public class ConfigStorageTest {
 
 		// sicherstellen, dass geladene Konfiguration der Standardkonfiguration entspricht
 		assertEquals(getConfigAsString(ConfigManager.getNewDefaultConfig()), getConfigAsString(emptyConfig));
+	}
+
+	/**
+	 * Testet, ob eine Konfiguration, nachdem sie gespeichert wurde, als nicht-geändert gilt.
+	 */
+	@Test
+	public final void testSavingConfigWillMarkItAsUnchanged() {
+		// Standardkonfiguration erzeugen
+		final Config config = ConfigManager.getNewDefaultConfig();
+		config.setChanged(true);
+
+		// Konfiguration speichern
+		new ConfigStorage().saveConfig(config, new ByteArrayOutputStream());
+
+		// sicherstellen, dass gespeicherte Konfiguration als nicht-geändert gilt 
+		assertFalse(config.isChanged());
+	}
+
+	/**
+	 * Testet, ob eine Konfiguration, nachdem sie geladen wurde, als nicht-geändert gilt.
+	 */
+	@Test
+	public final void testLoadingConfigWillMarkItAsUnchanged() {
+		// leere Konfiguration speichern
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try {
+			new Properties().storeToXML(out, null);
+		} catch (final IOException e) {
+			fail(e.getLocalizedMessage());
+		}
+
+		// gespeicherte Konfiguration laden, sollte dabei mit Standardwerten gefüllt werden
+		final ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		final Config emptyConfig = new ConfigStorage().loadConfig(in, true);
+
+		// sicherstellen, dass geladene Konfiguration als nicht-geändert gilt 
+		assertFalse(emptyConfig.isChanged());
 	}
 
 	/**

--- a/src/test/java/rmblworx/tools/timey/gui/config/ConfigTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/config/ConfigTest.java
@@ -1,0 +1,56 @@
+package rmblworx.tools.timey.gui.config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.Test;
+
+/**
+ * Test für die GUI-Konfiguration.
+ * 
+ * @author Christian Raue <christian.raue@gmail.com>
+ * @copyright 2014 Christian Raue
+ * @license http://opensource.org/licenses/mit-license.php MIT License
+ */
+public class ConfigTest {
+
+	/**
+	 * Testet den Änderungszustand der Konfiguration.
+	 * Stellt für jedes Attribut sicher,
+	 * <ul>
+	 * 	<li>dass die Konfiguration durch Setzen des gleichen Wertes als nicht geändert gilt und</li>
+	 * 	<li>dass die Konfiguration durch Setzen eines anderen Wertes als geändert gilt.</li>
+	 * </ul>
+	 */
+	@Test
+	public final void testChanged() {
+		Config config;
+
+		config = ConfigManager.getNewDefaultConfig();
+		config.setLocale(config.getLocale());
+		assertFalse(config.isChanged());
+		config.setLocale(Locale.ENGLISH);
+		assertTrue(config.isChanged());
+
+		config = ConfigManager.getNewDefaultConfig();
+		config.setMinimizeToTray(config.isMinimizeToTray());
+		assertFalse(config.isChanged());
+		config.setMinimizeToTray(!config.isMinimizeToTray());
+		assertTrue(config.isChanged());
+
+		config = ConfigManager.getNewDefaultConfig();
+		config.setStopwatchShowMilliseconds(config.isStopwatchShowMilliseconds());
+		assertFalse(config.isChanged());
+		config.setStopwatchShowMilliseconds(!config.isStopwatchShowMilliseconds());
+		assertTrue(config.isChanged());
+
+		config = ConfigManager.getNewDefaultConfig();
+		config.setActiveTab(config.getActiveTab());
+		assertFalse(config.isChanged());
+		config.setActiveTab(config.getActiveTab() + 1);
+		assertTrue(config.isChanged());
+	}
+
+}


### PR DESCRIPTION
Sorgt dafür, dass die Datei beim Beenden nicht sinnlos (neu) geschrieben wird.
