### PR TITLE
[GUI] Nutzung von Joda-Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ können.
 * Log4j
 * CGlib
 * AspectJWeaver
+* Joda-Time
 * JUnit
 * TestFX
 * Mockito

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<h2.version>1.3.175</h2.version>
 		<commons-dbcp.version>1.4</commons-dbcp.version>
 		<javafx.lib.ant-javafx.jar>${java.home}/../lib/ant-javafx.jar</javafx.lib.ant-javafx.jar>
+		<joda-time.version>2.3</joda-time.version>
 		<mockito.version>1.9.5</mockito.version>
 		<application.dist>${project.build.directory}/distribution</application.dist>
 		<maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
@@ -117,6 +118,11 @@
 			<groupId>org.jfxtras</groupId>
 			<artifactId>jfxtras-labs</artifactId>
 			<version>2.2-r5</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>${joda-time.version}</version>
 		</dependency>
 		<!-- Testing -->
 		<dependency>

--- a/src/main/java/rmblworx/tools/timey/gui/Alarm.java
+++ b/src/main/java/rmblworx/tools/timey/gui/Alarm.java
@@ -1,13 +1,13 @@
 package rmblworx.tools.timey.gui;
 
-import java.util.Calendar;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+
+import org.joda.time.LocalDateTime;
 
 /**
  * Alarm-VO für die GUI.
@@ -19,7 +19,7 @@ import javafx.beans.property.StringProperty;
 public class Alarm {
 
 	private final BooleanProperty enabled;
-	private final ObjectProperty<Calendar> dateTime;
+	private final ObjectProperty<LocalDateTime> dateTime;
 	private final StringProperty description;
 	private final StringProperty sound;
 
@@ -27,20 +27,20 @@ public class Alarm {
 	 * Initialisiert den Alarm mit der aktuellen Systemzeit.
 	 */
 	public Alarm() {
-		this(Calendar.getInstance(), null);
+		this(LocalDateTime.now(), null);
 	}
 
-	public Alarm(final Calendar dateTime, final String description) {
+	public Alarm(final LocalDateTime dateTime, final String description) {
 		this(dateTime, description, null, true);
 	}
 
-	public Alarm(final Calendar dateTime, final String description, final boolean enabled) {
+	public Alarm(final LocalDateTime dateTime, final String description, final boolean enabled) {
 		this(dateTime, description, null, enabled);
 	}
 
-	public Alarm(final Calendar dateTime, final String description, final String sound, final boolean enabled) {
+	public Alarm(final LocalDateTime dateTime, final String description, final String sound, final boolean enabled) {
 		this.enabled = new SimpleBooleanProperty(enabled);
-		this.dateTime = new SimpleObjectProperty<Calendar>(dateTime);
+		this.dateTime = new SimpleObjectProperty<LocalDateTime>(dateTime);
 		this.description = new SimpleStringProperty(description);
 		this.sound = new SimpleStringProperty(sound);
 	}
@@ -53,11 +53,11 @@ public class Alarm {
 		return enabled.get();
 	}
 
-	public void setDateTime(final Calendar dateTime) {
+	public void setDateTime(final LocalDateTime dateTime) {
 		this.dateTime.set(dateTime);
 	}
 
-	public Calendar getDateTime() {
+	public LocalDateTime getDateTime() {
 		return dateTime.get();
 	}
 

--- a/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
@@ -2,7 +2,6 @@ package rmblworx.tools.timey.gui;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.ResourceBundle;
 
 import javafx.application.Platform;
@@ -28,6 +27,8 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Callback;
 
+import org.joda.time.LocalDateTime;
+
 /**
  * Controller für die Alarm-GUI.
  * 
@@ -49,7 +50,7 @@ public class AlarmController extends Controller {
 	private TableView<Alarm> alarmTable;
 
 	@FXML
-	private TableColumn<Alarm, Calendar> alarmDateTimeColumn;
+	private TableColumn<Alarm, LocalDateTime> alarmDateTimeColumn;
 
 	@FXML
 	private TableColumn<Alarm, String> alarmDescriptionColumn;
@@ -69,14 +70,14 @@ public class AlarmController extends Controller {
 		assert alarmDeleteButton != null : "fx:id='alarmDeleteButton' was not injected";
 
 		if (alarmDateTimeColumn != null) {
-			alarmDateTimeColumn.setCellValueFactory(new PropertyValueFactory<Alarm, Calendar>("dateTime"));
+			alarmDateTimeColumn.setCellValueFactory(new PropertyValueFactory<Alarm, LocalDateTime>("dateTime"));
 
-			alarmDateTimeColumn.setCellFactory(new Callback<TableColumn<Alarm, Calendar>, TableCell<Alarm, Calendar>>() {
-				public TableCell<Alarm, Calendar> call(final TableColumn<Alarm, Calendar> param) {
-					return new TableCell<Alarm, Calendar>() {
-						protected void updateItem(final Calendar item, final boolean empty) {
+			alarmDateTimeColumn.setCellFactory(new Callback<TableColumn<Alarm, LocalDateTime>, TableCell<Alarm, LocalDateTime>>() {
+				public TableCell<Alarm, LocalDateTime> call(final TableColumn<Alarm, LocalDateTime> param) {
+					return new TableCell<Alarm, LocalDateTime>() {
+						protected void updateItem(final LocalDateTime item, final boolean empty) {
 							super.updateItem(item, empty);
-							setText(empty ? null : dateTimeFormatter.format(item.getTimeInMillis()));
+							setText(empty ? null : dateTimeFormatter.format(item.toDate().getTime()));
 						}
 					};
 				}
@@ -257,16 +258,11 @@ public class AlarmController extends Controller {
 	 * Fügt der Tabelle Beispieldaten hinzu.
 	 */
 	private void addSampleData() {
-		final Calendar cal1 = Calendar.getInstance();
-		cal1.add(Calendar.SECOND, 5);
-		final Calendar cal2 = Calendar.getInstance();
-		cal2.add(Calendar.SECOND, 10);
-		final Calendar cal3 = Calendar.getInstance();
-		cal3.add(Calendar.SECOND, 15);
+		final LocalDateTime now = LocalDateTime.now();
 		final ObservableList<Alarm> tableData = alarmTable.getItems();
-		tableData.add(new Alarm(cal1, "noch wird hier ..."));
-		tableData.add(new Alarm(cal2, "... nichts persistiert ..."));
-		tableData.add(new Alarm(cal3, "... oder ausgelöst", false));
+		tableData.add(new Alarm(now.secondOfMinute().addToCopy(5), "noch wird hier ..."));
+		tableData.add(new Alarm(now.secondOfMinute().addToCopy(10), "... nichts persistiert ..."));
+		tableData.add(new Alarm(now.secondOfMinute().addToCopy(15), "... oder ausgelöst", false));
 	}
 
 	/**

--- a/src/main/java/rmblworx/tools/timey/gui/AlarmEditDialogController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/AlarmEditDialogController.java
@@ -2,8 +2,6 @@ package rmblworx.tools.timey.gui;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -20,6 +18,10 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.util.Callback;
 import jfxtras.labs.scene.control.CalendarTextField;
+
+import org.joda.time.LocalDateTime;
+import org.joda.time.MutableDateTime;
+
 import rmblworx.tools.timey.gui.component.TimePicker;
 import rmblworx.tools.timey.gui.config.ConfigManager;
 
@@ -149,7 +151,7 @@ public class AlarmEditDialogController extends Controller {
 		this.alarm = alarm;
 
 		alarmEnabledCheckbox.setSelected(alarm.isEnabled());
-		alarmDatePicker.setValue(DateTimeUtil.getDatePart(alarm.getDateTime()));
+		alarmDatePicker.setValue(DateTimeUtil.getDatePart(alarm.getDateTime()).toDateTimeAtStartOfDay().toGregorianCalendar());
 		alarmTimePicker.setTime(DateTimeUtil.getTimePart(alarm.getDateTime()));
 		alarmDescriptionTextField.setText(alarm.getDescription());
 		ringtone.set(alarm.getSound());
@@ -272,13 +274,12 @@ public class AlarmEditDialogController extends Controller {
 	/**
 	 * @return kombinierter Zeitstempel aus DatePicker und TimePicker
 	 */
-	private Calendar getDateTimeFromPickers() {
-		final Calendar dateTime = (Calendar) alarmDatePicker.getValue().clone();
-		dateTime.setTimeInMillis(DateTimeUtil.getDatePart(alarmDatePicker.getValue()).getTimeInMillis()
-				+ dateTime.getTimeZone().getDSTSavings()
-				+ DateTimeUtil.getTimePart(alarmTimePicker.getTime()).getTimeInMillis());
+	private LocalDateTime getDateTimeFromPickers() {
+		final MutableDateTime mdt = new MutableDateTime(0);
+		mdt.add(alarmDatePicker.getValue().getTimeInMillis());
+		mdt.add(alarmTimePicker.getTime().getMillisOfDay());
 
-		return dateTime;
+		return mdt.toDateTime().toLocalDateTime();
 	}
 
 	/**
@@ -293,9 +294,9 @@ public class AlarmEditDialogController extends Controller {
 		}
 
 		if (alarmDatePicker.getValue() != null && existingAlarms != null) {
-			final Date selectedDateTime = getDateTimeFromPickers().getTime();
+			final LocalDateTime selectedDateTime = getDateTimeFromPickers();
 			for (final Alarm existingAlarm : existingAlarms) {
-				if (alarm != existingAlarm && selectedDateTime.equals(existingAlarm.getDateTime().getTime())) {
+				if (alarm != existingAlarm && selectedDateTime.equals(existingAlarm.getDateTime())) {
 					errors.append(resources.getString("alarmEdit.otherAlarmWithSameTimestampAlreadyExists"));
 					errors.append("\n");
 					break;

--- a/src/main/java/rmblworx/tools/timey/gui/CountdownController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/CountdownController.java
@@ -1,7 +1,6 @@
 package rmblworx.tools.timey.gui;
 
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
 
@@ -15,6 +14,10 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalTime;
+
 import rmblworx.tools.timey.ITimey;
 import rmblworx.tools.timey.event.CountdownExpiredEvent;
 import rmblworx.tools.timey.event.TimeyEvent;
@@ -73,14 +76,13 @@ public class CountdownController extends Controller implements TimeyEventListene
 		assert countdownTimeLabel != null : "fx:id='countdownTimeLabel' was not injected";
 		assert countdownTimePicker != null : "fx:id='countdownTimePicker' was not injected";
 
-		countdownTimePicker.setTimeZone(TIMEZONE);
-		setupTimeFormatters();
+		setupTimeFormatter();
 
 		// Start-Schaltfläche nur aktivieren, wenn Zeit > 0
 		countdownStartButton.setDisable(true);
-		countdownTimePicker.getTimeProperty().addListener(new ChangeListener<Calendar>() {
-			public void changed(final ObservableValue<? extends Calendar> property, final Calendar oldValue, final Calendar newValue) {
-				countdownStartButton.setDisable(newValue.getTimeInMillis() == 0L);
+		countdownTimePicker.getTimeProperty().addListener(new ChangeListener<LocalTime>() {
+			public void changed(final ObservableValue<? extends LocalTime> property, final LocalTime oldValue, final LocalTime newValue) {
+				countdownStartButton.setDisable(newValue.getMillisOfDay() == 0L);
 			}
 		});
 
@@ -125,7 +127,7 @@ public class CountdownController extends Controller implements TimeyEventListene
 			return;
 		}
 
-		final long millis = countdownTimePicker.getTime().getTimeInMillis();
+		final long millis = countdownTimePicker.getTime().getMillisOfDay();
 
 		if (millis == 0L) {
 			return;
@@ -193,9 +195,7 @@ public class CountdownController extends Controller implements TimeyEventListene
 
 		countdownRunning = false;
 
-		final Calendar cal = Calendar.getInstance(TIMEZONE);
-		cal.setTimeInMillis(getMillisRoundedToWholeSeconds(countdownValue - TimeZone.getDefault().getDSTSavings())); // TODO WTF?
-		countdownTimePicker.setTime(cal);
+		countdownTimePicker.setTime(new LocalTime(getMillisRoundedToWholeSeconds(countdownValue), DateTimeZone.UTC));
 
 		countdownStartButton.setVisible(true);
 		countdownStartButton.requestFocus();
@@ -216,7 +216,7 @@ public class CountdownController extends Controller implements TimeyEventListene
 	/**
 	 * Initialisiert den Zeitformatierer.
 	 */
-	private void setupTimeFormatters() {
+	private void setupTimeFormatter() {
 		if (timeFormatter == null) {
 			timeFormatter = new SimpleDateFormat("HH:mm:ss");
 			timeFormatter.setTimeZone(TIMEZONE);
@@ -238,7 +238,7 @@ public class CountdownController extends Controller implements TimeyEventListene
 	private void transferTimeFromInputToLabel() {
 		Platform.runLater(new Runnable() {
 			public void run() {
-				countdownTimeLabel.setText(timeFormatter.format(countdownTimePicker.getTime().getTime()));
+				countdownTimeLabel.setText(timeFormatter.format(countdownTimePicker.getTime().getMillisOfDay()));
 			}
 		});
 	}

--- a/src/main/java/rmblworx/tools/timey/gui/DateTimeUtil.java
+++ b/src/main/java/rmblworx/tools/timey/gui/DateTimeUtil.java
@@ -2,9 +2,10 @@ package rmblworx.tools.timey.gui;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
+
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
 
 /**
  * Hilfsmethoden zum Umgang mit Datum/Zeit-Werten.
@@ -15,74 +16,77 @@ import java.util.TimeZone;
  */
 public final class DateTimeUtil {
 
+	private static final String PATTERN_DATE_TIME = "dd.MM.yyyy HH:mm:ss";
+	private static final String PATTERN_DATE = "dd.MM.yyyy";
+	private static final String PATTERN_TIME = "HH:mm:ss";
+
 	/**
 	 * @param dateTime Datum-/Zeit-Wert
 	 * @return Datumsanteil in ms
 	 */
-	public static Calendar getDatePart(final Calendar dateTime) {
-		final Calendar date = (Calendar) dateTime.clone();
-
-		// Zeitanteil entfernen
-		date.set(Calendar.HOUR_OF_DAY, 0);
-		date.set(Calendar.MINUTE, 0);
-		date.set(Calendar.SECOND, 0);
-		date.set(Calendar.MILLISECOND, 0);
-
-		return date;
-
-//		// Zeitanteil entfernen
-//		return DateUtils.truncate(dateTime, Calendar.DATE);
+	public static LocalDate getDatePart(final LocalDateTime dateTime) {
+		return dateTime.toLocalDate();
 	}
 
 	/**
 	 * @param dateTime Datum-/Zeit-Wert
 	 * @return Zeitanteil in ms
 	 */
-	public static Calendar getTimePart(final Calendar dateTime) {
-		final Calendar time = (Calendar) dateTime.clone();
-
-		// Datumsanteil entfernen, @see http://stackoverflow.com/a/1363358
-		final long millisPerDay = 24 * 60 * 60 * 1000;
-		time.setTimeInMillis(dateTime.getTimeInMillis() % millisPerDay);
-
-		return time;
+	public static LocalTime getTimePart(final LocalDateTime dateTime) {
+		return dateTime.toLocalTime();
 	}
 
 	/**
-	 * Konvertiert einen Datum/Zeit-String in ein Kalender-Objekt.
 	 * @param string Datum/Zeit-Wert
-	 * @return Kalender mit entsprechendem Datum/Zeit-Wert
+	 * @return {@link LocalDateTime}-Objekt mit entsprechendem Datum/Zeit-Wert
 	 */
-	public static Calendar getCalendarForString(final String string) {
-		return getCalendarForString(string, TimeZone.getDefault());
-	}
-
-	/**
-	 * Konvertiert einen Datum/Zeit-String in ein Kalender-Objekt.
-	 * @param string Datum/Zeit-Wert
-	 * @param timeZone Zeitzone
-	 * @return Kalender mit entsprechendem Datum/Zeit-Wert
-	 */
-	public static Calendar getCalendarForString(final String string, final TimeZone timeZone) {
+	public static LocalDateTime getLocalDateTimeForString(final String string) {
 		final String[] patterns = {
-			"dd.MM.yyyy HH:mm:ss",
-			"dd.MM.yyyy",
-			"HH:mm:ss",
+			PATTERN_DATE_TIME,
+			PATTERN_DATE,
+			PATTERN_TIME,
 		};
 
+		return parseString(string, patterns);
+	}
+
+	/**
+	 * @param string Datum-Wert
+	 * @return {@link LocalDate}-Objekt mit entsprechendem Datum-Wert
+	 */
+	public static LocalDate getLocalDateForString(final String string) {
+		final String[] patterns = {
+			PATTERN_DATE,
+		};
+
+		return getDatePart(parseString(string, patterns));
+	}
+
+	/**
+	 * @param string Zeit-Wert
+	 * @return {@link LocalTime}-Objekt mit entsprechendem Zeit-Wert
+	 */
+	public static LocalTime getLocalTimeForString(final String string) {
+		final String[] patterns = {
+			PATTERN_TIME,
+		};
+
+		return getTimePart(parseString(string, patterns));
+	}
+
+	/**
+	 * @param string Datum/Zeit-Wert
+	 * @param patterns gültige Muster zum Parsen des Wertes
+	 * @return {@link LocalDateTime}-Objekt mit entsprechendem Datum/Zeit-Wert
+	 */
+	private static LocalDateTime parseString(final String string, final String[] patterns) {
 		final SimpleDateFormat dateFormat = new SimpleDateFormat();
-		dateFormat.setTimeZone(timeZone);
 
 		for (final String pattern : patterns) {
 			dateFormat.applyPattern(pattern);
 
 			try {
-				final Date dateTime = dateFormat.parse(string);
-
-				// wird nur aufgerufen, sobald keine Gefahr einer ParseException mehr besteht
-				final Calendar result = Calendar.getInstance(timeZone);
-				result.setTime(dateTime);
-				return result;
+				return new LocalDateTime(dateFormat.parse(string));
 			} catch (final ParseException e) {
 				continue;
 			}

--- a/src/main/java/rmblworx/tools/timey/gui/component/TimePicker.java
+++ b/src/main/java/rmblworx/tools/timey/gui/component/TimePicker.java
@@ -1,9 +1,6 @@
 package rmblworx.tools.timey.gui.component;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.TimeZone;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -19,6 +16,8 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.util.StringConverter;
+
+import org.joda.time.LocalTime;
 
 /**
  * JavaFX-Komponente zur Angabe einer Zeit bestehend aus Stunden, Minuten und Sekunden.
@@ -52,27 +51,7 @@ public class TimePicker extends AnchorPane {
 	/**
 	 * Zeit als Property.
 	 */
-	private final ObjectProperty<Calendar> timeProperty = new SimpleObjectProperty<Calendar>();
-
-	/**
-	 * Zeitzone.
-	 */
-	private TimeZone timeZone = TimeZone.getDefault();
-
-	/**
-	 * Formatiert Zeitstempel als Stunden-Werte.
-	 */
-	private SimpleDateFormat hoursFormatter;
-
-	/**
-	 * Formatiert Zeitstempel als Minuten-Werte.
-	 */
-	private SimpleDateFormat minutesFormatter;
-
-	/**
-	 * Formatiert Zeitstempel als Sekunden-Werte.
-	 */
-	private SimpleDateFormat secondsFormatter;
+	private final ObjectProperty<LocalTime> timeProperty = new SimpleObjectProperty<LocalTime>();
 
 	@FXML
 	private TextField hoursTextField;
@@ -94,9 +73,7 @@ public class TimePicker extends AnchorPane {
 
 	public TimePicker() {
 		// Zeit auf 0 setzen
-		final Calendar cal = Calendar.getInstance(timeZone);
-		cal.clear();
-		timeProperty.set(cal);
+		timeProperty.set(new LocalTime(0));
 
         createGui();
     }
@@ -133,44 +110,30 @@ public class TimePicker extends AnchorPane {
 		if (secondsTextField != null) {
 			bindTextInputListenersAndSlider(secondsTextField, secondsSlider, MAX_SECONDS);
 		}
-
-		setupTimeFormatters();
 	}
 
 	/**
 	 * @param time Zeit in ms
 	 */
-	public void setTime(final Calendar time) {
-		hoursTextField.setText(hoursFormatter.format(time.getTime()));
-		minutesTextField.setText(minutesFormatter.format(time.getTime()));
-		secondsTextField.setText(secondsFormatter.format(time.getTime()));
+	public void setTime(final LocalTime time) {
+		hoursTextField.setText(getTwoDigitValue(time.getHourOfDay()));
+		minutesTextField.setText(getTwoDigitValue(time.getMinuteOfHour()));
+		secondsTextField.setText(getTwoDigitValue(time.getSecondOfMinute()));
 	}
 
 	/**
 	 * @return Zeit in ms
 	 */
-	public Calendar getTime() {
-		final Calendar cal = Calendar.getInstance(timeZone);
-		cal.clear();
-		cal.add(Calendar.HOUR_OF_DAY, Integer.parseInt(hoursTextField.getText()));
-		cal.add(Calendar.MINUTE, Integer.parseInt(minutesTextField.getText()));
-		cal.add(Calendar.SECOND, Integer.parseInt(secondsTextField.getText()));
-
-		return cal;
+	public LocalTime getTime() {
+		return new LocalTime(Integer.parseInt(hoursTextField.getText()), Integer.parseInt(minutesTextField.getText()),
+				Integer.parseInt(secondsTextField.getText()));
 	}
 
 	/**
 	 * @return Zeit als Property
 	 */
-	public ObjectProperty<Calendar> getTimeProperty() {
+	public ObjectProperty<LocalTime> getTimeProperty() {
 		return timeProperty;
-	}
-
-	/**
-	 * @param timeZone Zeitzone
-	 */
-	public void setTimeZone(final TimeZone timeZone) {
-		this.timeZone = timeZone;
 	}
 
 	/**
@@ -263,26 +226,6 @@ public class TimePicker extends AnchorPane {
 	 */
 	private String getTwoDigitValue(final long value) {
 		return String.format("%02d", value);
-	}
-
-	/**
-	 * Initialisiert die Zeitformatierer.
-	 */
-	private void setupTimeFormatters() {
-		if (hoursFormatter == null) {
-			hoursFormatter = new SimpleDateFormat("HH");
-			hoursFormatter.setTimeZone(timeZone);
-		}
-
-		if (minutesFormatter == null) {
-			minutesFormatter = new SimpleDateFormat("mm");
-			minutesFormatter.setTimeZone(timeZone);
-		}
-
-		if (secondsFormatter == null) {
-			secondsFormatter = new SimpleDateFormat("ss");
-			secondsFormatter.setTimeZone(timeZone);
-		}
 	}
 
 }

--- a/src/test/java/rmblworx/tools/timey/gui/AlarmControllerTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/AlarmControllerTest.java
@@ -5,14 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import java.util.Calendar;
-
 import javafx.collections.ObservableList;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.TableView;
 
+import org.joda.time.LocalDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -115,20 +113,20 @@ public class AlarmControllerTest extends FxmlGuiControllerTest {
 
 		// Alarm anlegen
 		final ObservableList<Alarm> tableData = alarmTable.getItems();
-		final Alarm alarm1 = new Alarm(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00"), "Test");
+		final Alarm alarm1 = new Alarm(DateTimeUtil.getLocalDateTimeForString("24.12.2014 12:00:00"), "Test");
 		tableData.add(alarm1);
 
 		/*
 		 * Sicherstellen, dass Zellen die korrekten Objekte enthalten.
 		 * Wäre z. B. nicht der Fall, wenn der Name des Alarm-Attributs nicht mit dem Namen der Spalte übereinstimmt.
 		 */
-		final Object dateTimeCellData = alarmTable.getColumns().get(0).getCellData(0);
+		final LocalDateTime dateTimeCellData = (LocalDateTime) alarmTable.getColumns().get(0).getCellData(0);
 		assertNotNull(dateTimeCellData);
-		assertEquals(alarm1.getDateTime().getTime(), ((Calendar) dateTimeCellData).getTime());
+		assertEquals(alarm1.getDateTime(), dateTimeCellData);
 
-		final Object descriptionCellData = alarmTable.getColumns().get(1).getCellData(0);
+		final String descriptionCellData = (String) alarmTable.getColumns().get(1).getCellData(0);
 		assertNotNull(descriptionCellData);
-		assertEquals(alarm1.getDescription(), (String) descriptionCellData);
+		assertEquals(alarm1.getDescription(), descriptionCellData);
 	}
 
 }

--- a/src/test/java/rmblworx/tools/timey/gui/CountdownControllerTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/CountdownControllerTest.java
@@ -61,7 +61,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		assertFalse(countdownStopButton.isDisabled());
 
 		// Zeit setzen
-		countdownTimePicker.setTime(DateTimeUtil.getCalendarForString("00:00:10"));
+		countdownTimePicker.setTime(DateTimeUtil.getLocalTimeForString("00:00:10"));
 
 		// Zustand der Schaltflächen testen
 		assertTrue(countdownStartButton.isVisible());
@@ -94,7 +94,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		assertFalse(countdownStopButton.isDisabled());
 
 		// Zeit wieder auf 0 setzen
-		countdownTimePicker.setTime(DateTimeUtil.getCalendarForString("00:00:00"));
+		countdownTimePicker.setTime(DateTimeUtil.getLocalTimeForString("00:00:00"));
 
 		// Zustand der Schaltflächen testen
 		assertTrue(countdownStartButton.isVisible());
@@ -112,7 +112,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		final Label countdownTimeLabel = (Label) scene.lookup("#countdownTimeLabel");
 
 		// Zeit setzen
-		countdownTimePicker.setTime(DateTimeUtil.getCalendarForString("00:00:10"));
+		countdownTimePicker.setTime(DateTimeUtil.getLocalTimeForString("00:00:10"));
 
 		// Countdown starten
 		countdownStartButton.fire();
@@ -129,7 +129,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		FXTestUtils.awaitEvents();
 
 		// verbleibende Zeit muss stimmen
-		assertEquals(10000, countdownTimePicker.getTime().getTimeInMillis());
+		assertEquals(10000, countdownTimePicker.getTime().getMillisOfDay());
 
 		assertTrue(countdownTimePicker.isVisible());
 		assertFalse(countdownTimeLabel.isVisible());
@@ -143,7 +143,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		final TimePicker countdownTimePicker = (TimePicker) scene.lookup("#countdownTimePicker");
 
 		// Zeit auf 0 setzen
-		countdownTimePicker.setTime(DateTimeUtil.getCalendarForString("00:00:00"));
+		countdownTimePicker.setTime(DateTimeUtil.getLocalTimeForString("00:00:00"));
 		FXTestUtils.awaitEvents();
 
 		// bei Zeit = 0 darf sich Countdown nicht starten lassen
@@ -152,7 +152,7 @@ public class CountdownControllerTest extends FxmlGuiControllerTest {
 		verify(getController().getGuiHelper().getFacade(), never()).startCountdown();
 
 		// Zeit setzen
-		countdownTimePicker.setTime(DateTimeUtil.getCalendarForString("00:00:10"));
+		countdownTimePicker.setTime(DateTimeUtil.getLocalTimeForString("00:00:10"));
 		FXTestUtils.awaitEvents();
 
 		// Countdown starten

--- a/src/test/java/rmblworx/tools/timey/gui/DateTimeUtilTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/DateTimeUtilTest.java
@@ -2,9 +2,6 @@ package rmblworx.tools.timey.gui;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Calendar;
-import java.util.TimeZone;
-
 import org.junit.Test;
 
 /**
@@ -16,47 +13,94 @@ import org.junit.Test;
  */
 public class DateTimeUtilTest {
 
-	private static final TimeZone TZ_UTC = TimeZone.getTimeZone("UTC");
-	private static final TimeZone TZ_BERLIN = TimeZone.getTimeZone("Europe/Berlin");
-
 	/**
-	 * Testet {@link DateTimeUtil#getDatePart(Calendar)}.
+	 * Testet {@link DateTimeUtil#getDatePart(org.joda.time.LocalDateTime)}.
 	 */
 	@Test
 	public final void testGetDatePart() {
-		assertEquals(DateTimeUtil.getCalendarForString("24.12.2014").getTime(),
-				DateTimeUtil.getDatePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00")).getTime());
-		assertEquals(DateTimeUtil.getCalendarForString("24.12.2014", TZ_UTC).getTime(),
-				DateTimeUtil.getDatePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00", TZ_UTC)).getTime());
-		assertEquals(DateTimeUtil.getCalendarForString("24.12.2014", TZ_BERLIN).getTime(),
-				DateTimeUtil.getDatePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00", TZ_BERLIN)).getTime());
+		for (final DateTimePartsValue testCase : getDateTimeParts()) {
+			assertEquals(DateTimeUtil.getLocalDateForString(testCase.date),
+					DateTimeUtil.getDatePart(DateTimeUtil.getLocalDateTimeForString(testCase.dateTime)));
+		}
 	}
 
 	/**
-	 * Testet {@link DateTimeUtil#getTimePart(Calendar)}.
+	 * Testet {@link DateTimeUtil#getTimePart(org.joda.time.LocalDateTime)}.
 	 */
 	@Test
 	public final void testGetTimePart() {
-		assertEquals(DateTimeUtil.getCalendarForString("12:00:00").getTime(),
-				DateTimeUtil.getTimePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00")).getTime());
-		assertEquals(DateTimeUtil.getCalendarForString("12:00:00", TZ_UTC).getTime(),
-				DateTimeUtil.getTimePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00", TZ_UTC)).getTime());
-		assertEquals(DateTimeUtil.getCalendarForString("12:00:00", TZ_BERLIN).getTime(),
-				DateTimeUtil.getTimePart(DateTimeUtil.getCalendarForString("24.12.2014 12:00:00", TZ_BERLIN)).getTime());
+		for (final DateTimePartsValue testCase : getDateTimeParts()) {
+			assertEquals(DateTimeUtil.getLocalTimeForString(testCase.time),
+					DateTimeUtil.getTimePart(DateTimeUtil.getLocalDateTimeForString(testCase.dateTime)));
+		}
 	}
 
 	/**
-	 * Testet {@link DateTimeUtil#getCalendarForString(String, TimeZone))}.
+	 * Testet {@link DateTimeUtil#getLocalDateTimeForString(String)}.
 	 */
 	@Test
-	public final void testGetCalendarForString() {
-		assertEquals(0, DateTimeUtil.getCalendarForString("01.01.1970", TZ_UTC).getTimeInMillis());
-		assertEquals(0, DateTimeUtil.getCalendarForString("01.01.1970 00:00:00", TZ_UTC).getTimeInMillis());
-		assertEquals(0, DateTimeUtil.getCalendarForString("00:00:00", TZ_UTC).getTimeInMillis());
+	public final void testGetLocalDateTimeForString() {
+		final String[] strings = new String[] {
+			"01.01.1970 00:00:00",
+			"01.01.1970",
+			"00:00:00",
+		};
+		for (final String string : strings) {
+			assertEquals(String.format("Failed parsing and evaluating date/time string '%s'.", string),
+					0, DateTimeUtil.getLocalDateTimeForString(string).getMillisOfDay());
+		}
+	}
 
-		assertEquals(-3600000, DateTimeUtil.getCalendarForString("01.01.1970", TZ_BERLIN).getTimeInMillis());
-		assertEquals(-3600000, DateTimeUtil.getCalendarForString("01.01.1970 00:00:00", TZ_BERLIN).getTimeInMillis());
-		assertEquals(-3600000, DateTimeUtil.getCalendarForString("00:00:00", TZ_BERLIN).getTimeInMillis());
+	/**
+	 * Testet {@link DateTimeUtil#getLocalDateForString(String)}.
+	 */
+	@Test
+	public final void testGetLocalDateForString() {
+		final String[] strings = new String[] {
+			"01.01.1970",
+		};
+		for (final String string : strings) {
+			assertEquals(String.format("Failed parsing and evaluating date string '%s'.", string),
+					0, DateTimeUtil.getLocalDateForString(string).toDateTimeAtStartOfDay().getMillisOfDay());
+		}
+	}
+
+	/**
+	 * Testet {@link DateTimeUtil#getLocalTimeForString(String)}.
+	 */
+	@Test
+	public final void testGetLocalTimeForString() {
+		final String[] strings = new String[] {
+			"00:00:00",
+		};
+		for (final String string : strings) {
+			assertEquals(String.format("Failed parsing and evaluating time string '%s'.", string),
+					0, DateTimeUtil.getLocalTimeForString(string).getMillisOfDay());
+		}
+	}
+
+	/**
+	 * @return Testfälle
+	 */
+	private DateTimePartsValue[] getDateTimeParts() {
+		return new DateTimePartsValue[] {
+			new DateTimePartsValue("24.12.2014", "12:00:00"), // Zeitpunkt in Zeitzone "CET"
+			new DateTimePartsValue("04.04.2014", "12:00:00"), // Zeitpunkt in Zeitzone "CEST"
+		};
+	}
+
+	private final class DateTimePartsValue {
+
+		public final String date;
+		public final String time;
+		public final String dateTime;
+
+		public DateTimePartsValue(final String date, final String time) {
+			this.date = date;
+			this.time = time;
+			this.dateTime = String.format("%s %s", date, time);
+		}
+
 	}
 
 }

--- a/src/test/java/rmblworx/tools/timey/gui/component/TimePickerTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/component/TimePickerTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Calendar;
 import java.util.List;
 import java.util.Vector;
 
@@ -16,6 +15,7 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 
+import org.joda.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -244,12 +244,12 @@ public class TimePickerTest extends GuiTest {
 		testCases.add(new TimePartsAndTimeValue("00", "00", "00", "00:00:00"));
 
 		for (final TimePartsAndTimeValue testCase : testCases) {
-			final Calendar time = DateTimeUtil.getCalendarForString(testCase.timeString);
+			final LocalTime time = DateTimeUtil.getLocalTimeForString(testCase.timeString);
 			timePicker.setTime(time);
 			assertEquals(testCase.hours, hoursTextField.getText());
 			assertEquals(testCase.minutes, minutesTextField.getText());
 			assertEquals(testCase.seconds, secondsTextField.getText());
-			assertEquals(time.getTime(), timePicker.getTimeProperty().get().getTime());
+			assertEquals(time, timePicker.getTimeProperty().get());
 		}
 	}
 
@@ -268,12 +268,12 @@ public class TimePickerTest extends GuiTest {
 		testCases.add(new TimePartsAndTimeValue("00", "00", "00", "00:00:00"));
 
 		for (final TimePartsAndTimeValue testCase : testCases) {
-			final Calendar time = DateTimeUtil.getCalendarForString(testCase.timeString);
+			final LocalTime time = DateTimeUtil.getLocalTimeForString(testCase.timeString);
 			hoursTextField.setText(testCase.hours);
 			minutesTextField.setText(testCase.minutes);
 			secondsTextField.setText(testCase.seconds);
-			assertEquals(time.getTimeInMillis(), timePicker.getTime().getTimeInMillis());
-			assertEquals(time.getTimeInMillis(), timePicker.getTimeProperty().get().getTimeInMillis());
+			assertEquals(time, timePicker.getTime());
+			assertEquals(time, timePicker.getTimeProperty().get());
 		}
 	}
 


### PR DESCRIPTION
... statt Javas `Calendar`-Klasse, um Probleme mit Zeitzonen zu vermeiden (die derzeit z. B. beim Bearbeiten von Alarmen auftreten).
