### PR TITLE
Systemsprache als Standardsprache nutzen, Englisch als Fallback

### DIFF
--- a/src/main/java/rmblworx/tools/timey/gui/config/Config.java
+++ b/src/main/java/rmblworx/tools/timey/gui/config/Config.java
@@ -1,5 +1,6 @@
 package rmblworx.tools.timey.gui.config;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -12,9 +13,14 @@ import java.util.Locale;
 public class Config {
 
 	/**
-	 * Verfügbare Sprachen zur Auswahl in den Optionen.
+	 * Unterstützte Sprachen zur Auswahl in den Optionen.
 	 */
 	public static final Locale[] AVAILABLE_LOCALES = {Locale.GERMAN, Locale.ENGLISH};
+
+	/**
+	 * Fallback, falls eine nicht-unterstützte Sprache angefordert wurde.
+	 */
+	public static final Locale FALLBACK_LOCALE = Locale.ENGLISH;
 
 	/**
 	 * Ob die Konfiguration geändert wurde.
@@ -24,7 +30,7 @@ public class Config {
 	/**
 	 * Sprache.
 	 */
-	private Locale locale = Locale.GERMAN;
+	private Locale locale = getDefaultLocale();
 
 	/**
 	 * Ob die Anwendung ins System-Tray minimiert werden soll.
@@ -40,6 +46,19 @@ public class Config {
 	 * Aktiver Tab.
 	 */
 	private int activeTab = 0;
+
+	/**
+	 * @return Systemsprache, falls unterstützt, sonst Fallback
+	 */
+	public Locale getDefaultLocale() {
+		final Locale defaultLocale = Locale.forLanguageTag(Locale.getDefault().getLanguage());
+
+		if (Arrays.asList(AVAILABLE_LOCALES).contains(defaultLocale)) {
+			return defaultLocale;
+		}
+
+		return FALLBACK_LOCALE;
+	}
 
 	public void setChanged(final boolean changed) {
 		this.changed = changed;

--- a/src/test/java/rmblworx/tools/timey/gui/config/ConfigStorageTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/config/ConfigStorageTest.java
@@ -8,6 +8,9 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -33,12 +36,17 @@ public class ConfigStorageTest {
 		final ByteArrayOutputStream out = new ByteArrayOutputStream();
 		new ConfigStorage().saveConfig(config, out);
 
+		final Map<String, String> testCases = new HashMap<>(4);
+		testCases.put(ConfigStorage.PROP_LOCALE, String.format("%s", config.getLocale()));
+		testCases.put(ConfigStorage.PROP_MINIMIZE_TO_TRAY, String.format("%s", config.isMinimizeToTray()));
+		testCases.put(ConfigStorage.PROP_STOPWATCH_SHOW_MILLIS, String.format("%s", config.isStopwatchShowMilliseconds()));
+		testCases.put(ConfigStorage.PROP_ACTIVE_TAB, String.format("%d", config.getActiveTab()));
+
 		// sicherstellen, dass gespeicherte Konfiguration korrekte Einträge enthält
 		final String content = out.toString();
-		assertTrue(content, content.contains(String.format("<entry key=\"%s\">de</entry>", ConfigStorage.PROP_LOCALE)));
-		assertTrue(content, content.contains(String.format("<entry key=\"%s\">false</entry>", ConfigStorage.PROP_MINIMIZE_TO_TRAY)));
-		assertTrue(content, content.contains(String.format("<entry key=\"%s\">true</entry>", ConfigStorage.PROP_STOPWATCH_SHOW_MILLIS)));
-		assertTrue(content, content.contains(String.format("<entry key=\"%s\">0</entry>", ConfigStorage.PROP_ACTIVE_TAB)));
+		for (final Entry<String, String> testCase : testCases.entrySet()) {
+			assertTrue(content, content.contains(String.format("<entry key=\"%s\">%s</entry>", testCase.getKey(), testCase.getValue())));
+		}
 	}
 
 	/**

--- a/src/test/java/rmblworx/tools/timey/gui/config/ConfigTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/config/ConfigTest.java
@@ -1,10 +1,16 @@
 package rmblworx.tools.timey.gui.config;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -15,6 +21,35 @@ import org.junit.Test;
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
 public class ConfigTest {
+
+	private static Locale previousLocale;
+
+	@BeforeClass
+	public static final void setUpClass() {
+		previousLocale = Locale.getDefault();
+	}
+
+	@AfterClass
+	public static final void tearDownClass() {
+		Locale.setDefault(previousLocale);
+	}
+
+	@Test
+	/**
+	 * Testet {@link Config#getDefaultLocale()}.
+	 */
+	public final void testGetDefaultLocale() {
+		final Map<Locale, Locale> testCases = new HashMap<>(4);
+		testCases.put(new Locale("blah"), Locale.ENGLISH);
+		testCases.put(Locale.GERMANY, Locale.GERMAN);
+		testCases.put(Locale.GERMAN, Locale.GERMAN);
+		testCases.put(Locale.ENGLISH, Locale.ENGLISH);
+
+		for (final Entry<Locale, Locale> testCase : testCases.entrySet()) {
+			Locale.setDefault(testCase.getKey());
+			assertEquals(testCase.getValue(), ConfigManager.getNewDefaultConfig().getDefaultLocale());
+		}
+	}
 
 	/**
 	 * Testet den Änderungszustand der Konfiguration.


### PR DESCRIPTION
Bisher wurde immer Deutsch als Standardsprache genutzt, was auf anderssprachigen Systemen natürlich ungünstig ist.
