### PR TITLE
ID des in #113 hinzugefügten Repos geändert, um Warnung zu vermeiden

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
 
 	<repositories>
 		<repository>
-			<id>http://maven.xwiki.org</id>
+			<id>xwiki-externals</id>
 			<url>http://maven.xwiki.org/externals</url>
 		</repository>
 	</repositories>


### PR DESCRIPTION
Die Warnung lautet **'repositories.repository.id' must not contain any of these characters \/:"<>|?\* but found / @ line 393, column 8**.
