### PR TITLE
gebaute JAR-Datei wieder lauffähig gemacht (fixes #115)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
 									<fx:application refid="myApp" />
 
 									<manifest>
-										<attribute name="Class-Path" value="${manifest.classpath}" />
+										<attribute name="JavaFX-Class-Path" value="${manifest.classpath}" />
 										<attribute name="Implementation-Version" value="${project.version}" />
 										<attribute name="Bundle-Version" value="${project.version}" />
 									</manifest>


### PR DESCRIPTION
Das Attribut muss (warum auch immer) `JavaFX-Class-Path` statt `Class-Path` heißen.
