### PR TITLE
Behebung des Darstellungsfehlers nach Bearbeiten eines Alarms

### DIFF
--- a/src/main/java/rmblworx/tools/timey/gui/Alarm.java
+++ b/src/main/java/rmblworx/tools/timey/gui/Alarm.java
@@ -89,4 +89,24 @@ public class Alarm implements Comparable<Alarm> {
 		return getDateTime().toDateTime().getMillis() > other.getDateTime().toDateTime().getMillis() ? 1 : -1;
 	}
 
+	/*
+	 * Die "<Attribut>Property"-Methoden sorgen dafür, dass die Änderungen beim Bearbeiten eines Alarms korrekt in der Alarm-Tabelle
+	 * dargestellt werden. Siehe http://stackoverflow.com/questions/11065140/javafx-2-1-tableview-refresh-items/24194842#24194842.
+	 */
+	public BooleanProperty enabledProperty() {
+		return enabled;
+	}
+
+	public ObjectProperty<LocalDateTime> dateTimeProperty() {
+		return dateTime;
+	}
+
+	public StringProperty descriptionProperty() {
+		return description;
+	}
+
+	public StringProperty soundProperty() {
+		return sound;
+	}
+
 }

--- a/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
@@ -318,7 +318,21 @@ public class AlarmController extends Controller implements TimeyEventListener {
 	 * Aktualisiert den Inhalt der Tabelle.
 	 */
 	private void refreshTable() {
+		refreshTable(true);
+	}
+
+	/**
+	 * Aktualisiert den Inhalt der Tabelle.
+	 * @param preserveSelection Ob die Auswahl erhalten bleiben soll.
+	 */
+	private void refreshTable(final boolean preserveSelection) {
+		final int selectedIndex = alarmTable.getSelectionModel().getSelectedIndex();
+
 		FXCollections.sort(alarmTable.getItems());
+
+		if (preserveSelection) {
+			alarmTable.getSelectionModel().select(selectedIndex);
+		}
 	}
 
 	/**
@@ -359,11 +373,9 @@ public class AlarmController extends Controller implements TimeyEventListener {
 
 				final ObservableList<Alarm> tableData = alarmTable.getItems();
 				tableData.clear();
-				for (final Alarm alarm : alarms) {
-					tableData.add(alarm);
-				}
+				tableData.addAll(alarms);
 
-				refreshTable();
+				refreshTable(false);
 				alarmTable.getSelectionModel().select(selectedIndex);
 				hideProgress();
 


### PR DESCRIPTION
Nach Ändern z. B. der Zeit eines Alarms wird die Änderung nicht in der Tabelle angezeigt. Das Problem wird hierdurch gelöst.
