### PR TITLE
Umstellung von ClasspathSuite auf JUnit Toolbox zur Ermittlung aller Testklassen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<javafx.lib.ant-javafx.jar>${java.home}/../lib/ant-javafx.jar</javafx.lib.ant-javafx.jar>
 		<joda-time.version>2.4</joda-time.version>
 		<mockito.version>1.9.5</mockito.version>
-		<cpsuite.version>1.2.5</cpsuite.version>
+		<junit-toolbox.version>1.8</junit-toolbox.version>
 		<application.dist>${project.build.directory}/distribution</application.dist>
 		<maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
 		<maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
@@ -145,10 +145,9 @@
 			<version>${mockito.version}</version>
 		</dependency>
 		<dependency>
-			<!-- ClasspathSuite (http://www.johanneslink.net/projects/cpsuite.jsp) -->
-			<groupId>cpsuite</groupId>
-			<artifactId>cpsuite</artifactId>
-			<version>${cpsuite.version}</version>
+			<groupId>com.googlecode.junit-toolbox</groupId>
+			<artifactId>junit-toolbox</artifactId>
+			<version>${junit-toolbox.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -392,11 +391,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<repositories>
-		<repository>
-			<id>xwiki-externals</id>
-			<url>http://maven.xwiki.org/externals</url>
-		</repository>
-	</repositories>
 </project>

--- a/src/test/java/AllTests.java
+++ b/src/test/java/AllTests.java
@@ -1,5 +1,7 @@
-import org.junit.extensions.cpsuite.ClasspathSuite;
 import org.junit.runner.RunWith;
+
+import com.googlecode.junittoolbox.SuiteClasses;
+import com.googlecode.junittoolbox.WildcardPatternSuite;
 
 /*
  * Copyright 2014 Christian Raue
@@ -9,6 +11,11 @@ import org.junit.runner.RunWith;
  * Suite für alle Tests ohne spezifische Reihenfolge.
  * @author Christian Raue {@literal <christian.raue@gmail.com>}
  */
-@RunWith(ClasspathSuite.class)
+@RunWith(WildcardPatternSuite.class)
+@SuiteClasses({
+	"**/*Test.class",
+	"!rmblworx/tools/timey/gui/FxmlGuiControllerTest.class",
+	"!rmblworx/tools/timey/gui/FxmlGuiTest.class",
+})
 public class AllTests {
 }


### PR DESCRIPTION
Dadurch werden Probleme wie `Exception in thread "JavaFX Application Thread" java.util.concurrent.ExecutionException: java.lang.NoClassDefFoundError: javafx.scene.control.Control` beim Ausführen der Tests mit JavaFX 8 vermieden. Funktioniert allerdings ebenso gut wie bisher auch mit JavaFX 2.2, also kann die Umstellung schon mal vorgezogen werden.
