### PR TITLE
Änderungen an JavaFX-Komponenten immer auf dem JavaFX-Thread vornehmen

### DIFF
--- a/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/AlarmController.java
@@ -182,7 +182,7 @@ public class AlarmController extends Controller implements TimeyEventListener {
 
 							/*
 							 * Neuen Alarm auswählen.
-							 * Muss verzögert ausgeführt werden, um Darstellungsproblem beim Hinzufügen des ersten Alarms zu vermeiden. 
+							 * Muss verzögert ausgeführt werden, um Darstellungsproblem beim Hinzufügen des ersten Alarms zu vermeiden.
 							 * (Hinweis von https://community.oracle.com/message/10389376#10389376.)
 							 */
 							final int idx = alarmTable.getItems().indexOf(alarm);
@@ -355,8 +355,12 @@ public class AlarmController extends Controller implements TimeyEventListener {
 
 	private void switchProgress(final boolean visible) {
 		if (alarmProgressContainer != null && alarmContainer != null) {
-			alarmProgressContainer.setVisible(visible);
-			alarmContainer.setVisible(!visible);
+			Platform.runLater(new Runnable() {
+				public void run() {
+					alarmProgressContainer.setVisible(visible);
+					alarmContainer.setVisible(!visible);
+				}
+			});
 		}
 	}
 
@@ -369,16 +373,19 @@ public class AlarmController extends Controller implements TimeyEventListener {
 		getGuiHelper().runInThread(new Task<Void>() {
 			public Void call() {
 				final List<Alarm> alarms = AlarmDescriptorConverter.getAsAlarms(getGuiHelper().getFacade().getAllAlarms());
-
 				final int selectedIndex = alarmTable.getSelectionModel().getSelectedIndex();
-
 				final ObservableList<Alarm> tableData = alarmTable.getItems();
-				tableData.clear();
-				tableData.addAll(alarms);
 
-				refreshTable(false);
-				alarmTable.getSelectionModel().select(selectedIndex);
-				hideProgress();
+				Platform.runLater(new Runnable() {
+					public void run() {
+						tableData.clear();
+						tableData.addAll(alarms);
+
+						refreshTable(false);
+						alarmTable.getSelectionModel().select(selectedIndex);
+						hideProgress();
+					}
+				});
 
 				return null;
 			}

--- a/src/main/java/rmblworx/tools/timey/gui/AlarmEditDialogController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/AlarmEditDialogController.java
@@ -143,11 +143,15 @@ public class AlarmEditDialogController extends Controller {
 	public void setAlarm(final Alarm alarm) {
 		this.alarm = alarm;
 
-		alarmEnabledCheckbox.setSelected(alarm.isEnabled());
-		alarmDatePicker.setValue(DateTimeUtil.getDatePart(alarm.getDateTime()).toDateTimeAtStartOfDay().toGregorianCalendar());
-		alarmTimePicker.setTime(DateTimeUtil.getTimePart(alarm.getDateTime()));
-		alarmDescriptionTextField.setText(alarm.getDescription());
-		ringtone.set(alarm.getSound());
+		Platform.runLater(new Runnable() {
+			public void run() {
+				alarmEnabledCheckbox.setSelected(alarm.isEnabled());
+				alarmDatePicker.setValue(DateTimeUtil.getDatePart(alarm.getDateTime()).toDateTimeAtStartOfDay().toGregorianCalendar());
+				alarmTimePicker.setTime(DateTimeUtil.getTimePart(alarm.getDateTime()));
+				alarmDescriptionTextField.setText(alarm.getDescription());
+				ringtone.set(alarm.getSound());
+			}
+		});
 	}
 
 	public void setRingtone(final String aRingtone) {
@@ -170,21 +174,17 @@ public class AlarmEditDialogController extends Controller {
 	 */
 	@FXML
 	private void handleSelectSoundButtonClick() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				final FileChooser fileChooser = new FileChooser();
-				fileChooser.setTitle(resources.getString("sound.selectSound.title"));
-				fileChooser.setInitialDirectory(new File(System.getProperty("user.home")));
-				fileChooser.getExtensionFilters().addAll(
-					new FileChooser.ExtensionFilter("Sound", "*.aac", "*.aif", "*.aiff", "*.m3u8", "*.m4a", "*.mp3", "*.wav")
-				);
+		final FileChooser fileChooser = new FileChooser();
+		fileChooser.setTitle(resources.getString("sound.selectSound.title"));
+		fileChooser.setInitialDirectory(new File(System.getProperty("user.home")));
+		fileChooser.getExtensionFilters().addAll(
+			new FileChooser.ExtensionFilter("Sound", "*.aac", "*.aif", "*.aiff", "*.m3u8", "*.m4a", "*.mp3", "*.wav")
+		);
 
-				final File file = fileChooser.showOpenDialog(dialogStage);
-				if (file != null) {
-					ringtone.set(file.getPath());
-				}
-			}
-		});
+		final File file = fileChooser.showOpenDialog(dialogStage);
+		if (file != null) {
+			ringtone.set(file.getPath());
+		}
 	}
 
 	/**
@@ -192,11 +192,7 @@ public class AlarmEditDialogController extends Controller {
 	 */
 	@FXML
 	private void handleNoSoundButtonClick() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				ringtone.set(null);
-			}
-		});
+		ringtone.set(null);
 	}
 
 	/**
@@ -204,11 +200,7 @@ public class AlarmEditDialogController extends Controller {
 	 */
 	@FXML
 	private void handlePlaySoundButtonClick() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				getGuiHelper().playSoundInThread(ringtone.get(), resources);
-			}
-		});
+		getGuiHelper().playSoundInThread(ringtone.get(), resources);
 	}
 
 	/**
@@ -216,22 +208,18 @@ public class AlarmEditDialogController extends Controller {
 	 */
 	@FXML
 	private void handleSaveButtonClick() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				if (isInputValid()) {
-					alarm.setEnabled(alarmEnabledCheckbox.isSelected());
-					alarm.setDateTime(getDateTimeFromPickers());
-					alarm.setDescription(alarmDescriptionTextField.getText());
-					alarm.setSound(ringtone.get());
+		if (isInputValid()) {
+			alarm.setEnabled(alarmEnabledCheckbox.isSelected());
+			alarm.setDateTime(getDateTimeFromPickers());
+			alarm.setDescription(alarmDescriptionTextField.getText());
+			alarm.setSound(ringtone.get());
 
-					changed = true;
+			changed = true;
 
-					if (dialogStage != null) {
-						dialogStage.close();
-					}
-				}
+			if (dialogStage != null) {
+				dialogStage.close();
 			}
-		});
+		}
 	}
 
 	/**
@@ -239,13 +227,9 @@ public class AlarmEditDialogController extends Controller {
 	 */
 	@FXML
 	private void handleCancelButtonClick() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				if (dialogStage != null) {
-					dialogStage.close();
-				}
-			}
-		});
+		if (dialogStage != null) {
+			dialogStage.close();
+		}
 	}
 
 	/**

--- a/src/main/java/rmblworx/tools/timey/gui/CountdownController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/CountdownController.java
@@ -146,11 +146,15 @@ public class CountdownController extends Controller implements TimeyEventListene
 				facade.setCountdownTime(timeDescriptor);
 				facade.startCountdown();
 
-				countdownStartButton.setVisible(false);
-				countdownStopButton.setVisible(true);
-				countdownStopButton.requestFocus();
-				transferTimeFromInputToLabel();
-				enableTimeInput(false);
+				Platform.runLater(new Runnable() {
+					public void run() {
+						countdownStartButton.setVisible(false);
+						countdownStopButton.setVisible(true);
+						countdownStopButton.requestFocus();
+						transferTimeFromInputToLabel();
+						enableTimeInput(false);
+					}
+				});
 
 				while (countdownRunning) {
 					countdownValue = timeDescriptor.getMilliSeconds();
@@ -195,11 +199,15 @@ public class CountdownController extends Controller implements TimeyEventListene
 					getGuiHelper().getFacade().stopCountdown();
 				}
 
-				countdownTimePicker.setTime(new LocalTime(getMillisRoundedToWholeSeconds(countdownValue), DateTimeZone.UTC));
-				countdownStartButton.setVisible(true);
-				countdownStartButton.requestFocus();
-				countdownStopButton.setVisible(false);
-				enableTimeInput(true);
+				Platform.runLater(new Runnable() {
+					public void run() {
+						countdownTimePicker.setTime(new LocalTime(getMillisRoundedToWholeSeconds(countdownValue), DateTimeZone.UTC));
+						countdownStartButton.setVisible(true);
+						countdownStartButton.requestFocus();
+						countdownStopButton.setVisible(false);
+						enableTimeInput(true);
+					}
+				});
 
 				return null;
 			}
@@ -239,11 +247,7 @@ public class CountdownController extends Controller implements TimeyEventListene
 	 * Überträgt die Zeit von den Textfeldern auf das Label.
 	 */
 	private void transferTimeFromInputToLabel() {
-		Platform.runLater(new Runnable() {
-			public void run() {
-				countdownTimeLabel.setText(timeFormatter.format(countdownTimePicker.getTime().getMillisOfDay()));
-			}
-		});
+		countdownTimeLabel.setText(timeFormatter.format(countdownTimePicker.getTime().getMillisOfDay()));
 	}
 
 	/**

--- a/src/main/java/rmblworx/tools/timey/gui/StopwatchController.java
+++ b/src/main/java/rmblworx/tools/timey/gui/StopwatchController.java
@@ -120,10 +120,15 @@ public class StopwatchController extends Controller {
 			public Void call() {
 				getGuiHelper().getFacade().resetStopwatch();
 				stopwatchValue = 0L;
-				updateStopwatchTimeLabel();
-				stopwatchSplitTimeButton.setSelected(false);
-				stopwatchStopButton.setDisable(false);
-				stopwatchStartButton.requestFocus();
+
+				Platform.runLater(new Runnable() {
+					public void run() {
+						updateStopwatchTimeLabel();
+						stopwatchSplitTimeButton.setSelected(false);
+						stopwatchStopButton.setDisable(false);
+						stopwatchStartButton.requestFocus();
+					}
+				});
 
 				return null;
 			}
@@ -158,10 +163,14 @@ public class StopwatchController extends Controller {
 				final Config config = ConfigManager.getCurrentConfig();
 				final TimeDescriptor td = getGuiHelper().getFacade().startStopwatch();
 
-				stopwatchStartButton.setVisible(false);
-				stopwatchSplitTimeButton.setDisable(false);
-				stopwatchStopButton.setVisible(true);
-				stopwatchStopButton.requestFocus();
+				Platform.runLater(new Runnable() {
+					public void run() {
+						stopwatchStartButton.setVisible(false);
+						stopwatchSplitTimeButton.setDisable(false);
+						stopwatchStopButton.setVisible(true);
+						stopwatchStopButton.requestFocus();
+					}
+				});
 
 				while (stopwatchRunning) {
 					stopwatchValue = td.getMilliSeconds();
@@ -196,11 +205,15 @@ public class StopwatchController extends Controller {
 			public Void call() throws InterruptedException {
 				getGuiHelper().getFacade().stopStopwatch();
 
-				stopwatchStartButton.setVisible(true);
-				stopwatchStartButton.requestFocus();
-				stopwatchSplitTimeButton.setDisable(true);
-				stopwatchSplitTimeButton.setSelected(false);
-				stopwatchStopButton.setVisible(false);
+				Platform.runLater(new Runnable() {
+					public void run() {
+						stopwatchStartButton.setVisible(true);
+						stopwatchStartButton.requestFocus();
+						stopwatchSplitTimeButton.setDisable(true);
+						stopwatchSplitTimeButton.setSelected(false);
+						stopwatchStopButton.setVisible(false);
+					}
+				});
 
 				return null;
 			}
@@ -224,11 +237,7 @@ public class StopwatchController extends Controller {
 	 */
 	private void updateStopwatchTimeLabel() {
 		if (!stopwatchRunning) {
-			Platform.runLater(new Runnable() {
-				public void run() {
-					stopwatchTimeLabel.setText(timeFormatter.format(stopwatchValue));
-				}
-			});
+			stopwatchTimeLabel.setText(timeFormatter.format(stopwatchValue));
 		}
 	}
 


### PR DESCRIPTION
Dadurch sollten sich in Tests sporadisch auftretende `java.util.ConcurrentModificationException`s vermeiden lassen. Ist für JavaFX 8 zwingend erforderlich, um Änderungen sichtbar zu machen.
