### PR TITLE
Elternknoten für GUI-Tests in Container legen, um Steuerelemente nicht zu nah am Bildschirmrand zu platzieren

### DIFF
--- a/src/test/java/AllTests.java
+++ b/src/test/java/AllTests.java
@@ -16,6 +16,7 @@ import com.googlecode.junittoolbox.WildcardPatternSuite;
 	"**/*Test.class",
 	"!rmblworx/tools/timey/gui/FxmlGuiControllerTest.class",
 	"!rmblworx/tools/timey/gui/FxmlGuiTest.class",
+	"!rmblworx/tools/timey/gui/JavaFxGuiTest.class",
 })
 public class AllTests {
 }

--- a/src/test/java/rmblworx/tools/timey/gui/FxmlGuiTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/FxmlGuiTest.java
@@ -3,14 +3,10 @@ package rmblworx.tools.timey.gui;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
-import java.util.Locale;
 import java.util.ResourceBundle;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
-
-import org.loadui.testfx.GuiTest;
-
 import rmblworx.tools.timey.ITimey;
 
 /*
@@ -18,20 +14,10 @@ import rmblworx.tools.timey.ITimey;
  * MIT License http://opensource.org/licenses/mit-license.php
  */
 /**
- * Basisklasse für FXML-basierte GUI-Tests mit {@link https://github.com/SmartBear/TestFX}.
+ * Basisklasse für FXML-basierte GUI-Tests.
  * @author Christian Raue {@literal <christian.raue@gmail.com>}
  */
-public abstract class FxmlGuiTest extends GuiTest {
-
-	/**
-	 * Sprache für GUI-Tests.
-	 */
-	public static final Locale TEST_LOCALE = Locale.GERMAN;
-
-	static {
-		// Standardsprache für alle GUI-Tests setzen (wichtig z. B. als Fallback auf Travis)
-		Locale.setDefault(TEST_LOCALE);
-	}
+public abstract class FxmlGuiTest extends JavaFxGuiTest {
 
 	/**
 	 * Mit der GUI verbundener Controller.
@@ -57,7 +43,7 @@ public abstract class FxmlGuiTest extends GuiTest {
 			controller = loader.getController();
 			controller.setGuiHelper(guiHelper);
 			controllerLoaded();
-			return root;
+			return WRAP_IN_CONTAINER ? wrapInContainer(root) : root;
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return null;
@@ -65,7 +51,7 @@ public abstract class FxmlGuiTest extends GuiTest {
 	}
 
 	/**
-	 * Wird aufgerufen, sobald der Controller geladen wurde.
+	 * Wird aufgerufen sobald der Controller geladen wurde.
 	 */
 	protected void controllerLoaded() {
 	}

--- a/src/test/java/rmblworx/tools/timey/gui/JavaFxGuiTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/JavaFxGuiTest.java
@@ -1,0 +1,51 @@
+package rmblworx.tools.timey.gui;
+
+import java.util.Locale;
+
+import javafx.geometry.Insets;
+import javafx.scene.Parent;
+import javafx.scene.layout.BorderPane;
+
+import org.loadui.testfx.GuiTest;
+
+/*
+ * Copyright 2014 Christian Raue
+ * MIT License http://opensource.org/licenses/mit-license.php
+ */
+/**
+ * Basisklasse für JavaFX-basierte GUI-Tests mit {@link https://github.com/TestFX/TestFX}.
+ * @author Christian Raue {@literal <christian.raue@gmail.com>}
+ */
+public abstract class JavaFxGuiTest extends GuiTest {
+
+	/**
+	 * Ob der Elternknoten von einem Container umhüllt werden soll.
+	 */
+	protected static final boolean WRAP_IN_CONTAINER = true;
+
+	/**
+	 * Sprache für GUI-Tests.
+	 */
+	public static final Locale TEST_LOCALE = Locale.GERMAN;
+
+	static {
+		// Standardsprache für alle GUI-Tests setzen (wichtig z. B. als Fallback auf Travis)
+		Locale.setDefault(TEST_LOCALE);
+	}
+
+	/**
+	 * Legt einen Container um den Knoten, um die in ihm enthaltenen Steuerelemente während der Ausführung von Tests nicht am
+	 * Bildschirmrand zu platzieren.
+	 * Dient als Workaround für <a href="https://github.com/TestFX/TestFX/issues/136">TestFX/TestFX #136 auf GitHub</a>.
+	 * @param root zu umhüllender Elternknoten
+	 * @return Container als neuer Elternknoten
+	 */
+	protected final Parent wrapInContainer(final Parent root) {
+		final BorderPane container = new BorderPane();
+		container.setCenter(root);
+		container.setPadding(new Insets(150, 0, 0, 200));
+
+		return container;
+	}
+
+}

--- a/src/test/java/rmblworx/tools/timey/gui/component/TimePickerTest.java
+++ b/src/test/java/rmblworx/tools/timey/gui/component/TimePickerTest.java
@@ -20,11 +20,11 @@ import org.joda.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.loadui.testfx.GuiTest;
 import org.loadui.testfx.categories.TestFX;
 import org.loadui.testfx.utils.FXTestUtils;
 
 import rmblworx.tools.timey.gui.DateTimeUtil;
+import rmblworx.tools.timey.gui.JavaFxGuiTest;
 
 import com.google.common.base.Predicate;
 
@@ -37,7 +37,7 @@ import com.google.common.base.Predicate;
  * @author Christian Raue {@literal <christian.raue@gmail.com>}
  */
 @Category(TestFX.class)
-public class TimePickerTest extends GuiTest {
+public class TimePickerTest extends JavaFxGuiTest {
 
 	/**
 	 * Container für Elemente.
@@ -57,14 +57,14 @@ public class TimePickerTest extends GuiTest {
 	 * @return Elternknoten der GUI-Elemente
 	 */
 	protected final Parent getRootNode() {
-		return new TimePicker();
+		return WRAP_IN_CONTAINER ? wrapInContainer(new TimePicker()) : new TimePicker();
 	}
 
 	@Before
 	public final void setUp() {
 		scene = stage.getScene();
 
-		timePicker = (TimePicker) scene.getRoot();
+		timePicker = (TimePicker) (WRAP_IN_CONTAINER ? scene.getRoot().getChildrenUnmodifiable().get(0) : scene.getRoot());
 
 		hoursTextField = (TextField) scene.lookup("#hoursTextField");
 		minutesTextField = (TextField) scene.lookup("#minutesTextField");


### PR DESCRIPTION
Workaround für das Problem unter Mac OS X, dass simulierte Mausklicks auf der System-Menüleiste landen.
